### PR TITLE
Utilize AddItem to check for inventory fullness + NRE fix

### DIFF
--- a/AutoMine/BepInExPlugin.cs
+++ b/AutoMine/BepInExPlugin.cs
@@ -102,13 +102,16 @@ namespace AutoMine
             int count = 0;
             foreach (var m in FindObjectsOfType<ActionMinable>())
             {
-                if (player.GetPlayerBackpack().GetInventory().IsFull())
-                    return;
                 Vector2 pos = player.transform.position;
                 var dist = Vector2.Distance(m.transform.position, pos);
                 if (dist > maxRange.Value)
                     continue;
-                WorldObject worldObject = m.GetComponent<WorldObjectAssociated>().GetWorldObject();
+
+                var worldObjectAssociated = m.GetComponent<WorldObjectAssociated>();
+                if (worldObjectAssociated == null)
+                    continue;
+
+                WorldObject worldObject = worldObjectAssociated.GetWorldObject();
 
                 if (allowList.Value.Length > 0)
                 {
@@ -121,12 +124,18 @@ namespace AutoMine
                         continue;
                 }
 
-                Destroy(m.gameObject);
-                player.GetPlayerBackpack().GetInventory().AddItem(worldObject);
-                informationsDisplayer.AddInformation(2f, Readable.GetGroupName(worldObject.GetGroup()), DataConfig.UiInformationsType.InInventory, worldObject.GetGroup().GetImage());
-                worldObject.SetDontSaveMe(false);
-                Managers.GetManager<DisplayersHandler>().GetItemWorldDislpayer().Hide();
-                count++;
+                if (player.GetPlayerBackpack().GetInventory().AddItem(worldObject))
+                {
+                    Destroy(m.gameObject);
+                    informationsDisplayer.AddInformation(2f, Readable.GetGroupName(worldObject.GetGroup()), DataConfig.UiInformationsType.InInventory, worldObject.GetGroup().GetImage());
+                    worldObject.SetDontSaveMe(false);
+                    Managers.GetManager<DisplayersHandler>().GetItemWorldDislpayer().Hide();
+                    count++;
+                } 
+                else
+                {
+                    break;
+                }
             }
             if(count > 0)
             {


### PR DESCRIPTION
This PR proposes a fix to the case when Super Alloy game objects get destroyed and `GetComponent<WorldObjectAssociated>` returns null.

In addition, utilizing `AddItem` for inventory fullness check allows it to work with my inventory stacking mod's changes to how the game interprets fullness.

In addition, if the inventory becomes full, the player can still hear the grab sound.