### PR TITLE
QuickStore: don't remove item if AddItem fails (stacking workaround)

### DIFF
--- a/QuickStore/BepInExPlugin.cs
+++ b/QuickStore/BepInExPlugin.cs
@@ -105,11 +105,13 @@ namespace QuickStore
                     if (!ial[i].GetInventory().IsFull() && ial[i].GetInventory().GetInsideWorldObjects().Exists(o => o.GetGroup() == objects[j].GetGroup()))
                     {
                         Dbgl($"Storing {objects[j].GetGroup()} in {ial[i].name}");
-                        ial[i].GetInventory().AddItem(objects[j]);
-                        informationsDisplayer.AddInformation(2f, Readable.GetGroupName(objects[j].GetGroup()), DataConfig.UiInformationsType.OutInventory, objects[j].GetGroup().GetImage());
-                        Managers.GetManager<PlayersManager>().GetActivePlayerController().GetPlayerBackpack().GetInventory().RemoveItem(objects[j]);
-                        if (ial[i].GetInventory().IsFull())
-                            break;
+                        if (ial[i].GetInventory().AddItem(objects[j]))
+                        {
+                            informationsDisplayer.AddInformation(2f, Readable.GetGroupName(objects[j].GetGroup()), DataConfig.UiInformationsType.OutInventory, objects[j].GetGroup().GetImage());
+                            Managers.GetManager<PlayersManager>().GetActivePlayerController().GetPlayerBackpack().GetInventory().RemoveItem(objects[j]);
+                            if (ial[i].GetInventory().IsFull())
+                                break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
A user on [The Planet Crafter Discord](https://discord.com/channels/635441508694097921/882722354722127882/977638919493537813) reported a compatibility issue with my **Inventory Stacking** mod and **Quick Store** store.

With stacking, `IsFull` is no longer unconditional; an inventory might be full if the user wants to add a certain item and not full if they want to add something else. The former would need to start a new stack and the latter may be added to an existing stack.

This PR modifies the transfer operation to check if `AddItem` failed (the inventory was full with regards to the item type being added) and then not remove the item from the user's inventory.