### PR TITLE
Adding more config Option to customize Storing behavior

### DIFF
--- a/QuickStore/BepInExPlugin.cs
+++ b/QuickStore/BepInExPlugin.cs
@@ -3,11 +3,9 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using SpaceCraft;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using TMPro;
 using UnityEngine;
 using UnityEngine.InputSystem;
 

--- a/QuickStore/BepInExPlugin.cs
+++ b/QuickStore/BepInExPlugin.cs
@@ -3,9 +3,11 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using SpaceCraft;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using TMPro;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -23,6 +25,10 @@ namespace QuickStore
         private static ConfigEntry<string> allowList;
         private static ConfigEntry<string> disallowList;
         private static ConfigEntry<float> range;
+        private static ConfigEntry<bool> allowStoreIfContainerNameisexact;
+        private static ConfigEntry<bool> allowStoreIfContainerNameContains;
+        private static ConfigEntry<bool> requireNameFlagtoStore;
+        private static ConfigEntry<string> NameFlag;
 
         private static InputAction action;
 
@@ -43,6 +49,11 @@ namespace QuickStore
             allowList = Config.Bind<string>("Options", "AllowList", "", "Comma-separated list of item IDs to allow storing (overrides DisallowList).");
             disallowList = Config.Bind<string>("Options", "DisallowList", "", "Comma-separated list of item IDs to disallow storing (if AllowList is empty)");
             range = Config.Bind<float>("Options", "Range", 20f, "Store range (m)");
+            allowStoreIfContainerNameisexact = Config.Bind<bool>("Options", "allowStoreIfContainerNameisexact", true, "Allows to Store Item to an Container when it has the exact Name");
+            allowStoreIfContainerNameContains = Config.Bind<bool>("Options", "allowStoreIfContainerNameContains", true, "Allows to Store Item to an Container when it just Contains the Name of the Contant");
+            requireNameFlagtoStore = Config.Bind<bool>("Options", "requireNameFlagtoStore", false, "Requires a Nameflag beside the Object Name to Store stuff");
+            NameFlag = Config.Bind<string>("Sub-Options", "NameFlag", "AS", "(Only required if requireNameFlagtoStore set to true) One or More Characters, that stands free, also need to be in the Container Name to activate the Container for Storing. Example: \"AS Iron 3\" or \"Aluminium AS\" ");
+
 
             if (!storeKey.Value.Contains("<"))
                 storeKey.Value = "<Keyboard>/" + storeKey.Value;
@@ -105,7 +116,28 @@ namespace QuickStore
                         if (disallow.Contains(objects[j].GetGroup().GetId()))
                             continue;
                     }
-                    if (!inventory.IsFull() && (ial[i].GetComponent<WorldObjectText>()?.GetText() == Readable.GetGroupName(objects[j].GetGroup()) || inventory.GetInsideWorldObjects().Exists(o => o.GetGroup() == objects[j].GetGroup())))
+                    else if (inventory.IsFull()) continue;
+
+                    //Work with and Bool Flag to make to logic better to read.
+                    bool allownamedstore = false;
+                    //check if Storing, depeding on ContainerName is exactly the ObjectName, is allowed.
+                    if ( allowStoreIfContainerNameisexact.Value && ial[i].GetComponent<WorldObjectText>()?.GetText().ToLower() == Readable.GetGroupName(objects[j].GetGroup()).ToLower()) allownamedstore = true;
+                    //check if Storing, depeding on ContainerName contains ObjectName, is allowed. If yes check if Container has the Name to proceed
+                    if ( allowStoreIfContainerNameContains.Value && ( ial[i].GetComponent<WorldObjectText>().GetText().ToLower().Contains($" {Readable.GetGroupName(objects[j].GetGroup()).ToLower()} ") || ial[i].GetComponent<WorldObjectText>().GetText().ToLower().StartsWith($"{Readable.GetGroupName(objects[j].GetGroup()).ToLower()} ") || ial[i].GetComponent<WorldObjectText>().GetText().ToLower().EndsWith($" {Readable.GetGroupName(objects[j].GetGroup()).ToLower()}")) )
+                    {
+                            //Now check if a NameFlag is required
+                            if (requireNameFlagtoStore.Value)
+                            {
+                                //Check for the Name Flag. To make sure to not make a false positiv only accept free standing Flags. Include Start and End where a Space is missing.
+                                if ( ial[i].GetComponent<WorldObjectText>().GetText().ToLower().Contains($" {NameFlag.Value.ToLower()} ") || ial[i].GetComponent<WorldObjectText>().GetText().ToLower().StartsWith($"{NameFlag.Value.ToLower()} ") || ial[i].GetComponent<WorldObjectText>().GetText().ToLower().EndsWith($" {NameFlag.Value.ToLower()}")) allownamedstore = true;
+                            }
+                            else
+                            {
+                                allownamedstore = true;
+                            }
+                    }
+
+                    if (allownamedstore || inventory.GetInsideWorldObjects().Exists(o => o.GetGroup() == objects[j].GetGroup()) )
                     {
                         Dbgl($"Storing {objects[j].GetGroup()} in {ial[i].name}");
                         if (inventory.AddItem(objects[j]))

--- a/QuickStore/BepInExPlugin.cs
+++ b/QuickStore/BepInExPlugin.cs
@@ -23,6 +23,7 @@ namespace QuickStore
         private static ConfigEntry<string> allowList;
         private static ConfigEntry<string> disallowList;
         private static ConfigEntry<float> range;
+        private static ConfigEntry<bool> allowstoreIfContainerAlreadyContainsSameItem;
         private static ConfigEntry<bool> allowStoreIfContainerNameisexact;
         private static ConfigEntry<bool> allowStoreIfContainerNameContains;
         private static ConfigEntry<bool> requireNameFlagtoStore;
@@ -47,6 +48,7 @@ namespace QuickStore
             allowList = Config.Bind<string>("Options", "AllowList", "", "Comma-separated list of item IDs to allow storing (overrides DisallowList).");
             disallowList = Config.Bind<string>("Options", "DisallowList", "", "Comma-separated list of item IDs to disallow storing (if AllowList is empty)");
             range = Config.Bind<float>("Options", "Range", 20f, "Store range (m)");
+            allowstoreIfContainerAlreadyContainsSameItem = Config.Bind<bool>("Options", "allowstoreIfContainerAlreadyContainsSameItem", true, "Allows to Store Item to an Container when it already have the Same Item Type in it.");
             allowStoreIfContainerNameisexact = Config.Bind<bool>("Options", "allowStoreIfContainerNameisexact", true, "Allows to Store Item to an Container when it has the exact Name");
             allowStoreIfContainerNameContains = Config.Bind<bool>("Options", "allowStoreIfContainerNameContains", true, "Allows to Store Item to an Container when it just Contains the Name of the Contant");
             requireNameFlagtoStore = Config.Bind<bool>("Options", "requireNameFlagtoStore", false, "Requires a Nameflag beside the Object Name to Store stuff");
@@ -135,7 +137,7 @@ namespace QuickStore
                             }
                     }
 
-                    if (allownamedstore || inventory.GetInsideWorldObjects().Exists(o => o.GetGroup() == objects[j].GetGroup()) )
+                    if (allownamedstore || ( allowstoreIfContainerAlreadyContainsSameItem.Value && inventory.GetInsideWorldObjects().Exists(o => o.GetGroup() == objects[j].GetGroup()) ) )
                     {
                         Dbgl($"Storing {objects[j].GetGroup()} in {ial[i].name}");
                         if (inventory.AddItem(objects[j]))


### PR DESCRIPTION
Hi,
I very like your Mod. Thanks for that!
I personally missed some small things. That leads me to simply create it myself how I want it to have.
But as you may like the changes too, I will share them with you. 

What have I done:

Adding more config Option to customize Storing behavior.
Mostly for Storing to Named Container.
Previously, only a Container that has the Exact Name of the Item is accepted as target. 
But I prefer to add more information. So I added a Contains Function that storing works here too.
Additionally, you can also make it mandatory to contain a Name Flag to Store stuff. In case people want to split between Named Containers and Names sorting Containers.
As I already made a bunch of Stuff, I just added an option to disable the option to store stuff where already other stuff is stored.
For the Case People want to use Named Containers and still want to have random Misc Containers and want to avoid store more here.

From a Technical Perspective, I want to add, the storing option to Named Container had a bug where you are not able to Store Stuff that has a different Technical Name to the GUI shown one. Example here the Item Name is "Explosive powder" and not "Explosive Powder" like in the GUI. I just convert everything to Lower case before comparing, so the focus is on correct spelling than Case sensitive. (Thought about adding an option for player to choose Case sensitivity, but as I see it more as a Bug than feature, I didn't add it)
Now it's enough to write the Item Name correct.

Disclaimer. I tested the Mod for 2 Days now and also a bit the Options I would not play myself primary. For now all Scenarios work as expected. But as If-Else with deep Logic can be confusing, there is maybe still an Error/Bug OR an Option to improve/simplify the Code.

Please double-Check Description Text Spelling and Variable Names, I am not a native Speaker, so you may change things here to your preferred way.